### PR TITLE
adds utility to set sizes option to false when on a windows machine

### DIFF
--- a/.github/workflows/test-and-coverage-ubuntu.yml
+++ b/.github/workflows/test-and-coverage-ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           DISPLAY: ':99'
 
-      - name: Run Coverage Check
+      - name: Run Tests and Coverage Report
         run: npm run test:ci
         env:
           DISPLAY: ':99'

--- a/.github/workflows/test-and-coverage-windows.yml
+++ b/.github/workflows/test-and-coverage-windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Xvfb Equivalent (Headless GUI) - Skipped
         run: echo "XVFB not required on Windows"
 
-      - name: Run Coverage Check
+      - name: Run Tests and Coverage Report
         run: npm run test:ci
 
       - name: Upload Test Results

--- a/src/generateTreeFunctions.js
+++ b/src/generateTreeFunctions.js
@@ -9,6 +9,9 @@ const { convertToRegex } = require('./utils/conversions');
 const { getSafeSizesOption } = require('./utils/platformUtils');
 
 function generateTreeEverything(resource) {
+  if (os === 'win32') {
+    throw new Error('checking to see is my windows run will catch this');
+  }
   console.debug('generateTreeEverything method invoked...');
   try {
     const normalizedPath = validateResource(resource);

--- a/src/generateTreeFunctions.js
+++ b/src/generateTreeFunctions.js
@@ -2,9 +2,11 @@ const tree = require('tree-node-cli');
 const fs = require('fs');
 const vscode = require('vscode');
 const path = require('path');
+const os = require('os').platform();
 
 const { validateResource } = require('./utils/validations');
 const { convertToRegex } = require('./utils/conversions');
+const { getSafeSizesOption } = require('./utils/platformUtils');
 
 function generateTreeEverything(resource) {
   console.debug('generateTreeEverything method invoked...');
@@ -54,7 +56,7 @@ function generateTree(resource) {
       allFiles: config.get('allFiles', true),
       dirsFirst: config.get('dirsFirst', false),
       dirsOnly: config.get('dirsOnly', false),
-      sizes: config.get('sizes', false),
+      sizes: getSafeSizesOption(config),
       exclude: convertToRegex(
         config.get('exclude', ['/node_modules\//', '/venv\//', '/.git\//'])
       ),
@@ -67,11 +69,10 @@ function generateTree(resource) {
       ascii: config.get('ascii', true),
     };
 
-    let treeOutput = tree(normalizedPath, treeOptions);
-
+    treeOutput = tree(normalizedPath, treeOptions);
     vscode.env.clipboard.writeText(treeOutput);
     vscode.window.showInformationMessage('Generated tree copied to clipboard!');
-    console.debug('Tree generatred successfully!');
+    console.debug('Tree generated successfully!');
     return;
   } catch (e) {
     vscode.window.showErrorMessage(`Something went wrong: ${e.message}`);

--- a/src/generateTreeFunctions.js
+++ b/src/generateTreeFunctions.js
@@ -9,9 +9,6 @@ const { convertToRegex } = require('./utils/conversions');
 const { getSafeSizesOption } = require('./utils/platformUtils');
 
 function generateTreeEverything(resource) {
-  if (os === 'win32') {
-    throw new Error('checking to see is my windows run will catch this');
-  }
   console.debug('generateTreeEverything method invoked...');
   try {
     const normalizedPath = validateResource(resource);

--- a/src/utils/platformUtils.js
+++ b/src/utils/platformUtils.js
@@ -1,0 +1,25 @@
+const os = require('os').platform();
+const vscode = require('vscode');
+
+/**
+ * Safely retrieves the 'sizes' configuration for tree generation.
+ * Disables the option on Windows and notifies the user.
+ *
+ * @param {vscode.WorkspaceConfiguration} config - The VSCode configuration object
+ * @returns {boolean} - Whether the sizes option should be enabled
+ */
+function getSafeSizesOption(config) {
+  const sizesEnabled = config.get('sizes', false);
+
+  if (os === 'win32' && sizesEnabled) {
+    vscode.window.showWarningMessage('File sizes are not supported on Windows and have been disabled.');
+    console.info('File size option not included in treeOptions!');
+    return false;
+  }
+
+  return sizesEnabled;
+}
+
+module.exports = {
+  getSafeSizesOption,
+};

--- a/test/suite/generateFunctions/generateTreeFunction-default.test.js
+++ b/test/suite/generateFunctions/generateTreeFunction-default.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const vscode = require('vscode');
 const fs = require('fs');
 var proxyquire = require('proxyquire');
+const { getSafeSizesOption } = require('../../../src/utils/platformUtils');
 
 const pathToGenerateFunctions = '../../../src/generateTreeFunctions.js';
 suite('generateTree Command Test Suite', function () {
@@ -28,8 +29,8 @@ suite('generateTree Command Test Suite', function () {
       'showInformationMessage'
     );
     showErrorMessageSpy = sandbox.spy(vscode.window, 'showErrorMessage');
-
     existsSyncStub = sandbox.stub(fs, 'existsSync');
+    getSafeSizesOptionStub = sandbox.stub().returns(false);
   });
 
   teardown(function () {
@@ -47,11 +48,8 @@ suite('generateTree Command Test Suite', function () {
 
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
       'tree-node-cli': treeStub,
-      vscode: {
-        env: {
-          clipboard: mockClipboard,
-        },
-      },
+      vscode: { env: { clipboard: mockClipboard } },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
     });
     existsSyncStub.returns(true);
 
@@ -69,12 +67,9 @@ suite('generateTree Command Test Suite', function () {
     const mockClipboard = { writeText: mockClipboardWriteText };
 
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
-      vscode: {
-        env: {
-          clipboard: mockClipboard,
-        },
-      },
+      vscode: { env: { clipboard: mockClipboard } },
       './utils/validations': { validateResource: validateResourceStub },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
     });
 
     try {
@@ -111,6 +106,7 @@ suite('generateTree Command Test Suite', function () {
 
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
       './utils/validations': { validateResource: validateResourceStub },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
       'tree-node-cli': treeStub,
     });
 
@@ -133,11 +129,8 @@ suite('generateTree Command Test Suite', function () {
 
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
       'tree-node-cli': treeStub,
-      vscode: {
-        env: {
-          clipboard: mockClipboard,
-        },
-      },
+      vscode: { env: { clipboard: mockClipboard } },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
     });
     existsSyncStub.returns(true);
 
@@ -169,6 +162,7 @@ suite('generateTree Command Test Suite', function () {
       mockConfig.get.calledWith('ascii', true),
       'get() should be called with key "ascii" and default value true'
     );
+    assert(getSafeSizesOptionStub.calledOnce, 'getSafeSizesOption should not be called');
     assert(
       treeStub.calledWithMatch('/valid/path', {
         allFiles: false,
@@ -187,6 +181,7 @@ suite('generateTree Command Test Suite', function () {
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
       'tree-node-cli': treeStub,
       './utils/validations': { validateResource: validateResourceStub },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
       vscode: { env: { clipboard: mockClipboard } },
     });
 
@@ -208,6 +203,7 @@ suite('generateTree Command Test Suite', function () {
     const genTreeStub = proxyquire(pathToGenerateFunctions, {
       'tree-node-cli': treeStub,
       './utils/validations': { validateResource: validateResourceStub },
+      './utils/platformUtils': { getSafeSizesOption: getSafeSizesOptionStub },
     });
 
     await genTreeStub.generateTree(mockedUriResource);

--- a/test/suite/generateFunctions/generateTreeFunction-default.test.js
+++ b/test/suite/generateFunctions/generateTreeFunction-default.test.js
@@ -162,7 +162,7 @@ suite('generateTree Command Test Suite', function () {
       mockConfig.get.calledWith('ascii', true),
       'get() should be called with key "ascii" and default value true'
     );
-    assert(getSafeSizesOptionStub.calledOnce, 'getSafeSizesOption should not be called');
+    assert(getSafeSizesOptionStub.calledOnce, 'getSafeSizesOption should have be called');
     assert(
       treeStub.calledWithMatch('/valid/path', {
         allFiles: false,

--- a/test/suite/utils/platformUtils.test.js
+++ b/test/suite/utils/platformUtils.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const vscode = require('vscode');
+const proxyquire = require('proxyquire');
+
+suite('getSafeSizesOption', function () {
+  let sandbox;
+  let getSafeSizesOption;
+  let showWarningMessageStub;
+  let mockConfig;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+    showWarningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage');
+
+    mockConfig = {
+      get: sandbox.stub()
+    };
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  function loadPlatformUtilsWithMockedOS(osPlatform) {
+    getSafeSizesOption = proxyquire('../../../src/utils/platformUtils', {
+      os: { platform: () => osPlatform },
+      vscode: vscode
+    }).getSafeSizesOption;
+  }
+
+  test('should return false and show a warning on Windows when sizes is enabled', () => {
+    loadPlatformUtilsWithMockedOS('win32');
+    mockConfig.get.withArgs('sizes', false).returns(true);
+
+    const result = getSafeSizesOption(mockConfig);
+
+    assert.strictEqual(result, false, 'Expected sizes option to be false on Windows');
+    assert(showWarningMessageStub.calledOnce, 'Warning message should be shown on Windows');
+    assert(
+      showWarningMessageStub.calledWith('File sizes are not supported on Windows and have been disabled.'),
+      'Correct warning message should be shown'
+    );
+  });
+
+  test('should return false on Windows when sizes is disabled', () => {
+    loadPlatformUtilsWithMockedOS('win32');
+    mockConfig.get.withArgs('sizes', false).returns(false);
+
+    const result = getSafeSizesOption(mockConfig);
+
+    assert.strictEqual(result, false, 'Expected sizes option to remain false on Windows');
+    assert(showWarningMessageStub.notCalled, 'No warning message should be shown when sizes is false');
+  });
+
+  test('should return true on non-Windows OS when sizes is enabled', () => {
+    loadPlatformUtilsWithMockedOS('linux');
+    mockConfig.get.withArgs('sizes', false).returns(true);
+
+    const result = getSafeSizesOption(mockConfig);
+
+    assert.strictEqual(result, true, 'Expected sizes option to be true on non-Windows OS');
+    assert(showWarningMessageStub.notCalled, 'No warning should be shown on non-Windows OS');
+  });
+
+  test('should return false on non-Windows OS when sizes is disabled', () => {
+    loadPlatformUtilsWithMockedOS('darwin'); // macOS
+    mockConfig.get.withArgs('sizes', false).returns(false);
+
+    const result = getSafeSizesOption(mockConfig);
+
+    assert.strictEqual(result, false, 'Expected sizes option to remain false on non-Windows OS');
+    assert(showWarningMessageStub.notCalled, 'No warning should be shown when sizes is false');
+  });
+});


### PR DESCRIPTION
Related to #77 and #88 

Setting `sizes` option to false when OS is windows, until the du.exe dependency issue can be properly studied and solved.

### Results
![Screenshot 2025-01-14 at 3 23 46 PM](https://github.com/user-attachments/assets/2d597007-04d0-4bc8-9eff-ed710b5c528d)

